### PR TITLE
Fix typos & casing

### DIFF
--- a/SUCC/DataFiles/Abstractions/ReadableWritableDataFile.cs
+++ b/SUCC/DataFiles/Abstractions/ReadableWritableDataFile.cs
@@ -1,4 +1,4 @@
-﻿using SUCC.ParsingLogic;
+using SUCC.ParsingLogic;
 using System;
 using System.Linq;
 using System.Collections.Generic;
@@ -96,9 +96,9 @@ namespace SUCC.Abstractions
 
             if (!KeyExists(key))
             {
-                var newnode = new KeyNode(indentation: 0, key, file: this);
-                TopLevelNodes.Add(key, newnode);
-                TopLevelLines.Add(newnode);
+                var newNode = new KeyNode(indentation: 0, key, file: this);
+                TopLevelNodes.Add(key, newNode);
+                TopLevelLines.Add(newNode);
             }
 
             var node = TopLevelNodes[key];
@@ -141,9 +141,9 @@ namespace SUCC.Abstractions
 
             if (!KeyExists(path[0]))
             {
-                var newnode = new KeyNode(indentation: 0, key: path[0], file: this);
-                TopLevelNodes.Add(path[0], newnode);
-                TopLevelLines.Add(newnode);
+                var newNode = new KeyNode(indentation: 0, key: path[0], file: this);
+                TopLevelNodes.Add(path[0], newNode);
+                TopLevelLines.Add(newNode);
             }
 
             var topNode = TopLevelNodes[path[0]];
@@ -174,12 +174,12 @@ namespace SUCC.Abstractions
 
 
         /// <summary> Save this file as an object of type T, using that type's fields and properties as top-level keys. </summary>
-        public void SaveAsObject<T>(T savethis) => SaveAsObjectNonGeneric(typeof(T), savethis);
+        public void SaveAsObject<T>(T saveThis) => SaveAsObjectNonGeneric(typeof(T), saveThis);
 
         /// <summary> Non-generic version of SaveAsObject. You probably want to use SaveAsObject. </summary>
         /// <param name="type"> what type to save this object as </param>
-        /// <param name="savethis"> the object to save </param>
-        public void SaveAsObjectNonGeneric(Type type, object savethis)
+        /// <param name="saveThis"> the object to save </param>
+        public void SaveAsObjectNonGeneric(Type type, object saveThis)
         {
             bool previousAutosaveValue = AutoSave;
             AutoSave = false; // don't write to disk when we don't have to
@@ -187,7 +187,7 @@ namespace SUCC.Abstractions
             try
             {
                 foreach (var m in type.GetValidMembers())
-                    SetNonGeneric(m.MemberType, m.Name, m.GetValue(savethis));
+                    SetNonGeneric(m.MemberType, m.Name, m.GetValue(saveThis));
             }
             finally
             {

--- a/SUCC/Parsing Logic/DataConverter.cs
+++ b/SUCC/Parsing Logic/DataConverter.cs
@@ -76,26 +76,26 @@ namespace SUCC.ParsingLogic
                     if (parentNode.ChildNodeType != NodeChildrenType.multiLineString)
                         throw new Exception("oh no, we were supposed to be doing a multi-line string but the top of the node stack isn't a multi-line string node!");
 
-                    var newboi = new MultiLineStringNode(rawText: line, dataFile);
+                    var newBoi = new MultiLineStringNode(rawText: line, dataFile);
 
                     if (parentNode.ChildNodes.Count == 0)
                     {
                         // If this is the first line of the multi-line string, it determines the indentation level.
                         // However, that indentation level must be greater than the parent's.
-                        multiLineStringIndentationLevel = newboi.IndentationLevel;
+                        multiLineStringIndentationLevel = newBoi.IndentationLevel;
 
                         if (multiLineStringIndentationLevel <= parentNode.IndentationLevel)
                             throw new InvalidFileStructureException(dataFile, lineIndex, "multi-line string lines must have an indentation level greater than their parent");
                     }
                     else
                     {
-                        if (newboi.IndentationLevel != multiLineStringIndentationLevel)
+                        if (newBoi.IndentationLevel != multiLineStringIndentationLevel)
                             throw new InvalidFileStructureException(dataFile, lineIndex, "multi-line string lines must all have the same indentation level");
                     }
 
-                    parentNode.AddChild(newboi);
+                    parentNode.AddChild(newBoi);
 
-                    if (newboi.IsTerminator)
+                    if (newBoi.IsTerminator)
                     {
                         doingMultiLineString = false;
                         multiLineStringIndentationLevel = -1;

--- a/SUCC/Parsing Logic/NodeManager.cs
+++ b/SUCC/Parsing Logic/NodeManager.cs
@@ -1,4 +1,4 @@
-﻿using SUCC.ParsingLogic.CollectionTypes;
+using SUCC.ParsingLogic.CollectionTypes;
 using System;
 
 namespace SUCC.ParsingLogic
@@ -26,7 +26,7 @@ namespace SUCC.ParsingLogic
             // a base type in the type's static constructor.
             System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(type.TypeHandle);
 
-            // If we try to save a single-line string and find it is currently saved as a multi-line string, we do NOT remove the mutli-line formatting.
+            // If we try to save a single-line string and find it is currently saved as a multi-line string, we do NOT remove the multi-line formatting.
             // The reason for this is that there might be comments on the """s, and we want to preserve those comments.
             // Also, this happens in only two cases:
             //     1. A string that is usually single-line is manually switched to multi-line formatting by a user

--- a/SUCC/Parsing Logic/Nodes/KeyNode.cs
+++ b/SUCC/Parsing Logic/Nodes/KeyNode.cs
@@ -1,4 +1,4 @@
-﻿using SUCC.Abstractions;
+using SUCC.Abstractions;
 using System;
 
 namespace SUCC.ParsingLogic
@@ -44,18 +44,18 @@ namespace SUCC.ParsingLogic
             }
             set
             {
-                if (this.UnappliedStyle)
+                if (this.StyleNotYetApplied)
                 {
                     SetDataText(Key + ":".AddSpaces(Style.SpacesAfterColon) + value);
-                    this.UnappliedStyle = false;
+                    this.StyleNotYetApplied = false;
                     return;
                 }
 
                 var text = GetDataText();
                 int colonIndex = GetColonIndex(text);
 
-                string aftercolon = text.Substring(colonIndex + 1);
-                int spacesAfterColon = aftercolon.GetIndentationLevel();
+                string afterColon = text.Substring(colonIndex + 1);
+                int spacesAfterColon = afterColon.GetIndentationLevel();
 
                 SetDataText(
                     text.Substring(startIndex: 0, length: colonIndex + spacesAfterColon + 1) + value

--- a/SUCC/Parsing Logic/Nodes/ListNode.cs
+++ b/SUCC/Parsing Logic/Nodes/ListNode.cs
@@ -28,10 +28,10 @@ namespace SUCC.ParsingLogic
             }
             set
             {
-                if (this.UnappliedStyle)
+                if (this.StyleNotYetApplied)
                 {
                     SetDataText("-".AddSpaces(Style.SpacesAfterDash) + value);
-                    this.UnappliedStyle = false;
+                    this.StyleNotYetApplied = false;
                     return;
                 }
 

--- a/SUCC/Parsing Logic/Nodes/MultiLineStringNode.cs
+++ b/SUCC/Parsing Logic/Nodes/MultiLineStringNode.cs
@@ -10,7 +10,7 @@ namespace SUCC.ParsingLogic
         public MultiLineStringNode(string rawText, ReadableDataFile file) : base(rawText, file) { }
         public MultiLineStringNode(int indentation, ReadableDataFile file) : base(indentation, file)
         {
-            this.UnappliedStyle = false; // currently, no styles apply to MultiLineStringNodes
+            this.StyleNotYetApplied = false; // currently, no styles apply to MultiLineStringNodes
         }
 
         public override string Value

--- a/SUCC/Parsing Logic/Nodes/Node.cs
+++ b/SUCC/Parsing Logic/Nodes/Node.cs
@@ -46,10 +46,10 @@ namespace SUCC.ParsingLogic
             this.FileStyleRef = file as ReadableWritableDataFile;
 
             this.IndentationLevel = indentation;
-            this.UnappliedStyle = true;
+            this.StyleNotYetApplied = true;
         }
 
-        protected bool UnappliedStyle = false;
+        protected bool StyleNotYetApplied = false;
 
 
         public KeyNode GetChildAddressedByName(string name)
@@ -58,17 +58,17 @@ namespace SUCC.ParsingLogic
 
             foreach (var node in ChildNodes)
             {
-                var keynode = node as KeyNode;
-                if (keynode.Key == name) return keynode;
+                var keyNode = node as KeyNode;
+                if (keyNode.Key == name) return keyNode;
             }
 
             return CreateKeyNode(name);
             KeyNode CreateKeyNode(string key)
             {
-                var newnode = new KeyNode(GetProperChildIndentation(), key, File);
+                var newNode = new KeyNode(GetProperChildIndentation(), key, File);
 
-                AddChild(newnode);
-                return newnode;
+                AddChild(newNode);
+                return newNode;
             }
         }
 
@@ -80,14 +80,14 @@ namespace SUCC.ParsingLogic
             var indentation = GetProperChildIndentation();
             for (int i = ChildNodes.Count; i <= number; i++)
             {
-                var newnode = new ListNode(indentation, File);
-                AddChild(newnode);
+                var newNode = new ListNode(indentation, File);
+                AddChild(newNode);
             }
 
             return ChildNodes[number] as ListNode;
         }
 
-        public MultiLineStringNode GetChildAddresedByStringLineNumber(int number)
+        public MultiLineStringNode GetChildAddressedByStringLineNumber(int number)
         {
             EnsureProperChildType(NodeChildrenType.multiLineString);
 
@@ -95,8 +95,8 @@ namespace SUCC.ParsingLogic
             var indentation = GetProperChildIndentation();
             for (int i = ChildNodes.Count; i <= number; i++)
             {
-                var newnode = new MultiLineStringNode(indentation, File);
-                AddChild(newnode);
+                var newNode = new MultiLineStringNode(indentation, File);
+                AddChild(newNode);
             }
 
             return ChildNodes[number] as MultiLineStringNode;
@@ -156,8 +156,8 @@ namespace SUCC.ParsingLogic
         {
             foreach (var node in ChildNodes)
             {
-                var keynode = node as KeyNode;
-                if (keynode?.Key == key)
+                var keyNode = node as KeyNode;
+                if (keyNode?.Key == key)
                 {
                     _ChildNodes.Remove(node);
                     _ChildLines.Remove(node);

--- a/SUCC/Parsing Logic/Types/Base Types/Built-in base type logics/Float types.cs
+++ b/SUCC/Parsing Logic/Types/Base Types/Built-in base type logics/Float types.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Linq;
 
@@ -17,7 +17,7 @@ namespace SUCC.BuiltInBaseTypeRules
             if (float.IsNaN(value))
                 return FloatRulesConstants.NanText;
 
-            return value.ToString(FloatRulesConstants.NoScientificNotationInTostring, NumberFormatInfo.InvariantInfo);
+            return value.ToString(FloatRulesConstants.NoScientificNotationInToString, NumberFormatInfo.InvariantInfo);
         }
 
         public override float ParseItem(string text)
@@ -39,7 +39,7 @@ namespace SUCC.BuiltInBaseTypeRules
             if (double.IsNaN(value))
                 return FloatRulesConstants.NanText;
 
-            return value.ToString(FloatRulesConstants.NoScientificNotationInTostring, NumberFormatInfo.InvariantInfo);
+            return value.ToString(FloatRulesConstants.NoScientificNotationInToString, NumberFormatInfo.InvariantInfo);
         }
 
         public override double ParseItem(string text)
@@ -70,7 +70,7 @@ namespace SUCC.BuiltInBaseTypeRules
 
         // This lets us use decimal places instead of scientific notation. Yes, it's horrible.
         // See https://docs.microsoft.com/en-us/dotnet/api/system.single.tostring?view=netframework-4.7.2#System_Single_ToString_System_String_
-        public const string NoScientificNotationInTostring = "0.#####################################################################################################################################################################################################################################################################################################################################";
+        public const string NoScientificNotationInToString = "0.#####################################################################################################################################################################################################################################################################################################################################";
     }
 
     internal static class FloatRulesMathHelpers

--- a/SUCC/Parsing Logic/Types/Base Types/MultiLineStringSpecialCaseHandler.cs
+++ b/SUCC/Parsing Logic/Types/Base Types/MultiLineStringSpecialCaseHandler.cs
@@ -1,4 +1,4 @@
-﻿using SUCC.BuiltInBaseTypeRules;
+using SUCC.BuiltInBaseTypeRules;
 using System;
 
 namespace SUCC.ParsingLogic
@@ -19,16 +19,16 @@ namespace SUCC.ParsingLogic
 
                 for (int i = 0; i < lines.Length; i++)
                 {
-                    var newnode = node.GetChildAddresedByStringLineNumber(i);
+                    var newNode = node.GetChildAddressedByStringLineNumber(i);
                     string lineValue = BaseStringRules.SerializeItem(lines[i], style);
 
                     if (lineValue.EndsWith(MultiLineStringNode.NoLineBreakIndicator))
                         lineValue = lineValue.Quote();
 
-                    newnode.Value = lineValue;
+                    newNode.Value = lineValue;
                 }
 
-                node.GetChildAddresedByStringLineNumber(lines.Length).MakeTerminator();
+                node.GetChildAddressedByStringLineNumber(lines.Length).MakeTerminator();
                 return;
             }
             else

--- a/SUCC/Parsing Logic/Types/Complex Types/ComplexTypeShortcuts.cs
+++ b/SUCC/Parsing Logic/Types/Complex Types/ComplexTypeShortcuts.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 
 namespace SUCC.ParsingLogic
@@ -81,8 +81,8 @@ namespace SUCC.ParsingLogic
             try { 
             if (shortcut.Contains("(") && shortcut.Contains(")"))
             {
-                string methodname = shortcut.Substring(0, shortcut.IndexOf('('));
-                var method = type.GetMethod(methodname, BindingFlags.Public | BindingFlags.Static);
+                string methodName = shortcut.Substring(0, shortcut.IndexOf('('));
+                var method = type.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
 
                 if (method != null && method.ReturnType == type)
                 {


### PR DESCRIPTION
Fixes some more typos.
Fixes the casing of some variable names to be camel cased.
Changes one field name entirely to be more clear about its purpose.

Also removes `UTF-8 BOM` from some files.