### PR TITLE
Update TargetFramework of JECS

### DIFF
--- a/JECS.Tests/JECS.Tests.csproj
+++ b/JECS.Tests/JECS.Tests.csproj
@@ -9,8 +9,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JECS/JECS.csproj
+++ b/JECS/JECS.csproj
@@ -1,16 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Using 'netstandard2.0' can drag some projects down. And there are a couple of benefits of using 'netstandard2.1'. The recent Unity versions also support netstandard2.1.

Removing 'System.ValueTuple' dependency, cause that is included in the new target framework.
Also removing 'Microsoft.CSharp' - I actually do not know what it was used for. But it does not seem to be required for compilation.